### PR TITLE
Add support for React 18.x in the dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "react-dnd-scrolling",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.2.2",
+      "name": "react-dnd-scrolling",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "hoist-non-react-statics": "3.x",
@@ -40,9 +41,9 @@
         "typescript": "^4.6.3"
       },
       "peerDependencies": {
-        "react": "16.x || 17.x",
+        "react": "16.x || 17.x || 18.x",
         "react-dnd": "10.x || 11.x || 14.x || 15.x",
-        "react-dom": "16.x || 17.x"
+        "react-dom": "16.x || 17.x || 18.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
     "typescript": "^4.6.3"
   },
   "peerDependencies": {
-    "react": "16.x || 17.x",
+    "react": "16.x || 17.x || 18.x",
     "react-dnd": "10.x || 11.x || 14.x || 15.x",
-    "react-dom": "16.x || 17.x"
+    "react-dom": "16.x || 17.x || 18.x"
   }
 }


### PR DESCRIPTION
Passes tests so it should be fine to add support for React 18 in the dependencies, right?