### PR TITLE
Add esm bundling

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
   "extends": ["airbnb", "plugin:prettier/recommended"],
 
   "rules": {
+    "import/extensions": "off",
     "import/no-unresolved": "warn",
     "no-else-return": "off",
     "no-plusplus": "off",

--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+	require: ['@babel/register', 'test/setup.js'],
+	ui: 'bdd',
+  "node-option": [
+    "loader=@node-loader/babel",
+  ]
+}

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,4 +1,0 @@
-module.exports = {
-	require: ['@babel/register', 'test/setup'],
-	ui: 'bdd',
-}

--- a/babel.config.cjs.json
+++ b/babel.config.cjs.json
@@ -1,0 +1,6 @@
+{
+  "presets": [
+    "@babel/preset-env",
+    "@babel/preset-react"
+  ]
+}

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,6 +1,17 @@
 {
   "presets": [
-    "@babel/preset-env",
-    "@babel/preset-react"
+    [
+      "@babel/preset-env",
+      {
+        "loose": true,
+        "modules": false
+      }
+    ],
+    [
+      "@babel/preset-react",
+      {
+        "runtime": "automatic"
+      }
+    ]
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-dnd-scrolling",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-dnd-scrolling",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
         "hoist-non-react-statics": "3.x",
@@ -22,6 +22,7 @@
         "@babel/preset-env": "^7.16.11",
         "@babel/preset-react": "^7.16.7",
         "@babel/register": "^7.17.7",
+        "@node-loader/babel": "^2.0.1",
         "chai": "^4.3.6",
         "eslint": "^8.12.0",
         "eslint-config-airbnb": "^19.0.4",
@@ -34,7 +35,7 @@
         "mocha": "^9.2.2",
         "prettier": "^2.6.1",
         "react": "^18.0.0",
-        "react-dnd": "^15.1.1",
+        "react-dnd": "^16.0.1",
         "react-dom": "^18.0.0",
         "sinon": "^13.0.1",
         "sinon-chai": "^3.7.0",
@@ -42,7 +43,7 @@
       },
       "peerDependencies": {
         "react": "16.x || 17.x || 18.x",
-        "react-dnd": "10.x || 11.x || 14.x || 15.x",
+        "react-dnd": "10.x || 11.x || 14.x || 15.x || 16.x",
         "react-dom": "16.x || 17.x || 18.x"
       }
     },
@@ -2014,22 +2015,28 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/@node-loader/babel": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@node-loader/babel/-/babel-2.0.1.tgz",
+      "integrity": "sha512-lulESaNn+jyn4lCbfcFWFcRYchsL0jY8q/mf5XRKOiX2uTpkXE3fGAlZ4+wyP/hIAMSlDPuHIUkRSTkJZ6SQyA==",
+      "dev": true
+    },
     "node_modules/@react-dnd/asap": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-4.0.0.tgz",
-      "integrity": "sha512-0XhqJSc6pPoNnf8DhdsPHtUhRzZALVzYMTzRwV4VI6DJNJ/5xxfL9OQUwb8IH5/2x7lSf7nAZrnzUD+16VyOVQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-5.0.2.tgz",
+      "integrity": "sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==",
       "dev": true
     },
     "node_modules/@react-dnd/invariant": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-3.0.0.tgz",
-      "integrity": "sha512-keberJRIqPX15IK3SWS/iO1t/kGETiL1oczKrDitAaMnQ+kpHf81l3MrRmFjvfqcnApE+izEvwM6GsyoIcpsVA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-4.0.2.tgz",
+      "integrity": "sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==",
       "dev": true
     },
     "node_modules/@react-dnd/shallowequal": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-3.0.0.tgz",
-      "integrity": "sha512-1ELWQdJB2UrCXTKK5cCD9uGLLIwECLIEdttKA255owdpchtXohIjZBTlFJszwYi2ZKe2Do+QvUzsGyGCMNwbdw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz",
+      "integrity": "sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==",
       "dev": true
     },
     "node_modules/@sinonjs/commons": {
@@ -2784,14 +2791,14 @@
       }
     },
     "node_modules/dnd-core": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-15.1.1.tgz",
-      "integrity": "sha512-Mtj/Sltcx7stVXzeDg4g7roTe/AmzRuIf/FYOxX6F8gULbY54w066BlErBOzQfn9RIJ3gAYLGX7wvVvoBSq7ig==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-16.0.1.tgz",
+      "integrity": "sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==",
       "dev": true,
       "dependencies": {
-        "@react-dnd/asap": "4.0.0",
-        "@react-dnd/invariant": "3.0.0",
-        "redux": "^4.1.1"
+        "@react-dnd/asap": "^5.0.1",
+        "@react-dnd/invariant": "^4.0.1",
+        "redux": "^4.2.0"
       }
     },
     "node_modules/doctrine": {
@@ -5050,14 +5057,14 @@
       "integrity": "sha512-I+vcaK9t4+kypiSgaiVWAipqHRXYmZIuAiS8vzFvXHHXVigg/sMKwlRgLy6LH2i3rmP+0Vzfl5lFsFRwF1r3pg=="
     },
     "node_modules/react-dnd": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-15.1.1.tgz",
-      "integrity": "sha512-QLrHtPU08U4c5zop0ANeqrHXaQw2EWLMn8DQoN6/e4eSN/UbB84P49/80Qg0MEF29VLB5vikSoiFh9N8ASNmpQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.1.tgz",
+      "integrity": "sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==",
       "dev": true,
       "dependencies": {
-        "@react-dnd/invariant": "3.0.0",
-        "@react-dnd/shallowequal": "3.0.0",
-        "dnd-core": "15.1.1",
+        "@react-dnd/invariant": "^4.0.1",
+        "@react-dnd/shallowequal": "^4.0.1",
+        "dnd-core": "^16.0.1",
         "fast-deep-equal": "^3.1.3",
         "hoist-non-react-statics": "^3.3.2"
       },
@@ -5098,9 +5105,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/redux": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
-      "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"
@@ -7190,22 +7197,28 @@
       "dev": true,
       "optional": true
     },
+    "@node-loader/babel": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@node-loader/babel/-/babel-2.0.1.tgz",
+      "integrity": "sha512-lulESaNn+jyn4lCbfcFWFcRYchsL0jY8q/mf5XRKOiX2uTpkXE3fGAlZ4+wyP/hIAMSlDPuHIUkRSTkJZ6SQyA==",
+      "dev": true
+    },
     "@react-dnd/asap": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-4.0.0.tgz",
-      "integrity": "sha512-0XhqJSc6pPoNnf8DhdsPHtUhRzZALVzYMTzRwV4VI6DJNJ/5xxfL9OQUwb8IH5/2x7lSf7nAZrnzUD+16VyOVQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-5.0.2.tgz",
+      "integrity": "sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==",
       "dev": true
     },
     "@react-dnd/invariant": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-3.0.0.tgz",
-      "integrity": "sha512-keberJRIqPX15IK3SWS/iO1t/kGETiL1oczKrDitAaMnQ+kpHf81l3MrRmFjvfqcnApE+izEvwM6GsyoIcpsVA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-4.0.2.tgz",
+      "integrity": "sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==",
       "dev": true
     },
     "@react-dnd/shallowequal": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-3.0.0.tgz",
-      "integrity": "sha512-1ELWQdJB2UrCXTKK5cCD9uGLLIwECLIEdttKA255owdpchtXohIjZBTlFJszwYi2ZKe2Do+QvUzsGyGCMNwbdw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz",
+      "integrity": "sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==",
       "dev": true
     },
     "@sinonjs/commons": {
@@ -7786,14 +7799,14 @@
       "dev": true
     },
     "dnd-core": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-15.1.1.tgz",
-      "integrity": "sha512-Mtj/Sltcx7stVXzeDg4g7roTe/AmzRuIf/FYOxX6F8gULbY54w066BlErBOzQfn9RIJ3gAYLGX7wvVvoBSq7ig==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-16.0.1.tgz",
+      "integrity": "sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==",
       "dev": true,
       "requires": {
-        "@react-dnd/asap": "4.0.0",
-        "@react-dnd/invariant": "3.0.0",
-        "redux": "^4.1.1"
+        "@react-dnd/asap": "^5.0.1",
+        "@react-dnd/invariant": "^4.0.1",
+        "redux": "^4.2.0"
       }
     },
     "doctrine": {
@@ -9462,14 +9475,14 @@
       "integrity": "sha512-I+vcaK9t4+kypiSgaiVWAipqHRXYmZIuAiS8vzFvXHHXVigg/sMKwlRgLy6LH2i3rmP+0Vzfl5lFsFRwF1r3pg=="
     },
     "react-dnd": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-15.1.1.tgz",
-      "integrity": "sha512-QLrHtPU08U4c5zop0ANeqrHXaQw2EWLMn8DQoN6/e4eSN/UbB84P49/80Qg0MEF29VLB5vikSoiFh9N8ASNmpQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.1.tgz",
+      "integrity": "sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==",
       "dev": true,
       "requires": {
-        "@react-dnd/invariant": "3.0.0",
-        "@react-dnd/shallowequal": "3.0.0",
-        "dnd-core": "15.1.1",
+        "@react-dnd/invariant": "^4.0.1",
+        "@react-dnd/shallowequal": "^4.0.1",
+        "dnd-core": "^16.0.1",
         "fast-deep-equal": "^3.1.3",
         "hoist-non-react-statics": "^3.3.2"
       }
@@ -9490,9 +9503,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "redux": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
-      "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
         "hoist-non-react-statics": "3.x",
         "lodash.throttle": "^4.1.1",
         "prop-types": "15.x",
-        "raf": "^3.4.1",
-        "react-display-name": "^0.2.5"
+        "raf": "^3.4.1"
       },
       "devDependencies": {
         "@babel/cli": "^7.17.6",
@@ -5051,11 +5050,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-display-name": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/react-display-name/-/react-display-name-0.2.5.tgz",
-      "integrity": "sha512-I+vcaK9t4+kypiSgaiVWAipqHRXYmZIuAiS8vzFvXHHXVigg/sMKwlRgLy6LH2i3rmP+0Vzfl5lFsFRwF1r3pg=="
-    },
     "node_modules/react-dnd": {
       "version": "16.0.1",
       "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.1.tgz",
@@ -9468,11 +9462,6 @@
       "requires": {
         "loose-envify": "^1.1.0"
       }
-    },
-    "react-display-name": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/react-display-name/-/react-display-name-0.2.5.tgz",
-      "integrity": "sha512-I+vcaK9t4+kypiSgaiVWAipqHRXYmZIuAiS8vzFvXHHXVigg/sMKwlRgLy6LH2i3rmP+0Vzfl5lFsFRwF1r3pg=="
     },
     "react-dnd": {
       "version": "16.0.1",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,22 @@
   "name": "react-dnd-scrolling",
   "version": "1.2.4",
   "description": "A cross browser solution to scrolling during drag and drop.",
-  "main": "lib/index.js",
+  "type": "module",
+  "exports": {
+    "util": {
+      "import": "./lib/esm/util.js",
+      "require": "./lib/cjs/util.cjs"
+    },
+    "default": {
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.cjs"
+    }
+  },
   "types": "types/index.d.ts",
   "scripts": {
-    "build": "rm -rf lib && babel src --out-dir lib",
+    "build": "rm -rf lib && npm run build:cjs && npm run build:esm",
+    "build:cjs": "babel --config-file ./babel.config.cjs.json src --out-dir lib/cjs",
+    "build:esm": "babel src --out-dir lib/esm",
     "lint": "eslint src",
     "pretest": "npm run lint",
     "test": "mocha test",
@@ -38,6 +50,7 @@
     "react-display-name": "^0.2.5"
   },
   "devDependencies": {
+    "@node-loader/babel": "^2.0.1",
     "@babel/cli": "^7.17.6",
     "@babel/core": "^7.17.8",
     "@babel/eslint-parser": "^7.17.0",
@@ -56,7 +69,7 @@
     "mocha": "^9.2.2",
     "prettier": "^2.6.1",
     "react": "^18.0.0",
-    "react-dnd": "^15.1.1",
+    "react-dnd": "^16.0.1",
     "react-dom": "^18.0.0",
     "sinon": "^13.0.1",
     "sinon-chai": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "hoist-non-react-statics": "3.x",
     "lodash.throttle": "^4.1.1",
     "prop-types": "15.x",
-    "raf": "^3.4.1",
-    "react-display-name": "^0.2.5"
+    "raf": "^3.4.1"
   },
   "devDependencies": {
     "@node-loader/babel": "^2.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -4,11 +4,17 @@ import { DndContext } from 'react-dnd';
 import { findDOMNode } from 'react-dom';
 import throttle from 'lodash.throttle';
 import raf from 'raf';
-import getDisplayName from 'react-display-name';
 import hoist from 'hoist-non-react-statics';
 import { noop, intBetween, getCoords } from './util.js';
 
 const DEFAULT_BUFFER = 150;
+
+const getDisplayName = PassedComponent =>
+  PassedComponent.displayName ||
+  PassedComponent.name ||
+  (typeof PassedComponent === 'string' && PassedComponent.length > 0
+    ? PassedComponent
+    : 'Unknown');
 
 export function createHorizontalStrength(_buffer) {
   return function defaultHorizontalStrength({ x, w, y, h }, point) {

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import throttle from 'lodash.throttle';
 import raf from 'raf';
 import getDisplayName from 'react-display-name';
 import hoist from 'hoist-non-react-statics';
-import { noop, intBetween, getCoords } from './util';
+import { noop, intBetween, getCoords } from './util.js';
 
 const DEFAULT_BUFFER = 150;
 

--- a/test/intBetween.js
+++ b/test/intBetween.js
@@ -1,17 +1,16 @@
-import { intBetween } from '../src/util';
+import { intBetween } from '../src/util.js';
 
 describe('private intBetween()', () => {
-
   it('should return val if it is an int between min and max', () => {
     expect(intBetween(0, 2, 1)).to.equal(1);
   });
 
   it('should floor the val if it not an int', () => {
-    expect(intBetween(0, 2, .5)).to.equal(0);
+    expect(intBetween(0, 2, 0.5)).to.equal(0);
   });
 
   it('should take the floor of the min if its the bigger than val and not an int', () => {
-    expect(intBetween(.5, 2, -1)).to.equal(0);
+    expect(intBetween(0.5, 2, -1)).to.equal(0);
   });
 
   it('should take the floor of the max if its lower than val and not an int', () => {

--- a/test/strength-creators-test.js
+++ b/test/strength-creators-test.js
@@ -1,10 +1,10 @@
-import { createHorizontalStrength, createVerticalStrength } from '../src';
+import { createHorizontalStrength, createVerticalStrength } from '../src/index.js';
 
 describe('strength functions', function () {
-  let hFn = createHorizontalStrength(150);
-  let vFn = createVerticalStrength(150);
-  let box = { x: 0, y: 0, w: 600, h: 600 };
-  let lilBox = { x: 0, y: 0, w: 100, h: 100 };
+  const hFn = createHorizontalStrength(150);
+  const vFn = createVerticalStrength(150);
+  const box = { x: 0, y: 0, w: 600, h: 600 };
+  const lilBox = { x: 0, y: 0, w: 100, h: 100 };
 
   describe('horizontalStrength', function () {
     it('should return -1 when all the way at the left', function () {


### PR DESCRIPTION
Currently, this library is not compatible with react-dnd 16+ when used in an ESM environment. We get this error message:
```
Error [ERR_REQUIRE_ESM]: require() of ES Module /code/node_modules/react-dnd/dist/index.js from /code/node_modules/react-dnd-scrolling/lib/index.js not supported.
Instead change the require of /code/node_modules/react-dnd/dist/index.js in /code/node_modules/react-dnd-scrolling/lib/index.js to a dynamic import() which is available in all CommonJS modules.
```

This PR adds ESM builds to this library. It should be fully backwards compatible, since commonJS builds are still being generated as well.


For anyone wanting to try out this fork, adjust your `react-dnd-scrolling` dependency in your package json like so:
```
"react-dnd-scrolling": "npm:tobilen-react-dnd-scrolling@^1.2.4",
```