### PR TITLE
Refactor to be hook based

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,34 @@ export default class App extends Component {
 }
 ```
 
-Note: You should replace the original `div` you would like to make scrollable with the `ScrollingComponent`. 
+Note: You should replace the original `div` you would like to make scrollable with the `ScrollingComponent`.
+
+### useDndScrolling
+```js
+import React, { Component, useRef } from 'react';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import { useDndScrolling } from 'react-dnd-scrolling';
+import DragItem from './DragItem';
+import './App.css';
+
+const ITEMS = [1,2,3,4,5,6,7,8,9,10];
+
+export default function App() {
+  const ref = useRef();
+  useDndScrolling(ref);
+
+  return (
+    <DndProvider backend={HTML5Backend}>
+      <div ref={ref} className="App">
+        {ITEMS.map(n => (
+          <DragItem key={n} label={`Item ${n}`} />
+        ))}
+      </div>
+    </DndProvider>
+  );
+}
+```
 
 ### Easing Example
 
@@ -92,7 +119,7 @@ export default App(props) {
   );
 }
 ```
-Note: You should replace the original `div` you would like to make scrollable with the `ScrollingComponent`. 
+Note: You should replace the original `div` you would like to make scrollable with the `ScrollingComponent`.
 
 ### Virtualized Example
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
+        "defaults": "^1.0.4",
         "hoist-non-react-statics": "3.x",
         "lodash.throttle": "^4.1.1",
         "prop-types": "15.x",
@@ -2585,6 +2586,14 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/clone-deep": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -2767,6 +2776,17 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/define-properties": {
       "version": "1.1.3",
@@ -7619,6 +7639,11 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="
+    },
     "clone-deep": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -7764,6 +7789,14 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "requires": {
+        "clone": "^1.0.2"
+      }
     },
     "define-properties": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -43,19 +43,20 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "defaults": "^1.0.4",
     "hoist-non-react-statics": "3.x",
     "lodash.throttle": "^4.1.1",
     "prop-types": "15.x",
     "raf": "^3.4.1"
   },
   "devDependencies": {
-    "@node-loader/babel": "^2.0.1",
     "@babel/cli": "^7.17.6",
     "@babel/core": "^7.17.8",
     "@babel/eslint-parser": "^7.17.0",
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-react": "^7.16.7",
     "@babel/register": "^7.17.7",
+    "@node-loader/babel": "^2.0.1",
     "chai": "^4.3.6",
     "eslint": "^8.12.0",
     "eslint-config-airbnb": "^19.0.4",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import type { DragDropManager } from 'dnd-core';
 
 export type BoxType = {
   x: number;
@@ -9,17 +10,29 @@ export type BoxType = {
 
 export type StrengthFuncton = (box: BoxType, point: number) => number;
 
-export default function withScrolling<
-  T extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<T>,
-  P = React.ComponentProps<T>
->(
-  component: T
-): React.ComponentType<
-  P & {
+export function useDndScrolling(
+  ref: React.Ref<any>,
+  options: {
     verticalStrength?: StrengthFuncton;
     horizontalStrength?: StrengthFuncton;
+    strengthMultiplier?: number;
+    onScrollChange?: (newLeft: number, newTop: number) => void;
+    dragDropManager?: DragDropManager;
   }
->;
+): void;
 
 export function createHorizontalStrength(_buffer: number): StrengthFuncton;
 export function createVerticalStrength(_buffer: number): StrengthFuncton;
+
+export default function withScrolling<
+  T extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<T>,
+  P = React.ComponentProps<T>
+  >(
+  component: T
+): React.ComponentType<
+  P & {
+  verticalStrength?: StrengthFuncton;
+  horizontalStrength?: StrengthFuncton;
+  dragDropManager?: DragDropManager;
+}
+  >;


### PR DESCRIPTION
I kept running into issues that were hard to pin down, so i decided to rewrite this library from a class to a hook.

This PR should not have any breaking changes (unless you're using React versions not supporting hooks), and introduce a new named export, `useDndScrolling`. Example usage is written in the readme.

It should definitely improve performance though (according to my lighthouse tests, the page containing it is 2 points faster already)

For anyone wanting to try out this fork, adjust your `react-dnd-scrolling` dependency in your package json like so:
```
"react-dnd-scrolling": "npm:tobilen-react-dnd-scrolling@^1.3.2",
```