### PR TITLE
Fix typo in exported StrengthFunction type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,21 +13,23 @@ interface Point {
   y: number;
 }
 
-export type StrengthFuncton = (box: BoxType, point: Point) => number;
+export type StrengthFunction = (box: BoxType, point: Point) => number;
+/** @deprecated use `StrengthFunction` instead */
+export type StrengthFuncton = StrengthFunction;
 
 export function useDndScrolling(
   ref: React.Ref<any>,
   options: {
-    verticalStrength?: StrengthFuncton;
-    horizontalStrength?: StrengthFuncton;
+    verticalStrength?: StrengthFunction;
+    horizontalStrength?: StrengthFunction;
     strengthMultiplier?: number;
     onScrollChange?: (newLeft: number, newTop: number) => void;
     dragDropManager?: DragDropManager;
   }
 ): void;
 
-export function createHorizontalStrength(_buffer: number): StrengthFuncton;
-export function createVerticalStrength(_buffer: number): StrengthFuncton;
+export function createHorizontalStrength(_buffer: number): StrengthFunction;
+export function createVerticalStrength(_buffer: number): StrengthFunction;
 
 export default function withScrolling<
   T extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<T>,
@@ -36,8 +38,8 @@ export default function withScrolling<
   component: T
 ): React.ComponentType<
   P & {
-    verticalStrength?: StrengthFuncton;
-    horizontalStrength?: StrengthFuncton;
+    verticalStrength?: StrengthFunction;
+    horizontalStrength?: StrengthFunction;
     dragDropManager?: DragDropManager;
   }
 >;


### PR DESCRIPTION
To preserve backwards compatibility, I preserved a type export under the old name as well, and I marked it as deprecated so that tools like VSCode will show users the new name inline.