### PR TITLE
Fix useDndScroll when componentRef.current is initialized with null

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-dnd-scrolling",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-dnd-scrolling",
-      "version": "1.3.1",
+      "version": "1.3.3",
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.4",

--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@ export function useDndScrolling(componentRef, passedOptions) {
     return () => {
       monitor.stop();
     };
-  }, [componentRef, dragDropManager, passedOptions]);
+  }, [componentRef.current, dragDropManager, passedOptions]);
 }
 
 export default function createScrollingComponent(WrappedComponent) {


### PR DESCRIPTION
 if componentRef.current is initially null,   ScrollingMonitor will not initiate when ref changes later 
